### PR TITLE
Quote output strings & skip the `vendor` directory

### DIFF
--- a/internal/collect.go
+++ b/internal/collect.go
@@ -20,6 +20,15 @@ type testf struct {
 	Name string
 }
 
+func ignoreDir(name string) bool {
+	switch name {
+	case "testdata", "vendor":
+		return true
+	default:
+		return false
+	}
+}
+
 func Collect(root string) ([]testf, error) {
 	tests := []testf{}
 	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
@@ -28,7 +37,7 @@ func Collect(root string) ([]testf, error) {
 		}
 
 		// Don't collect testdata directories.
-		if info.IsDir() && filepath.Base(info.Name()) == "testdata" {
+		if info.IsDir() && ignoreDir(filepath.Base(info.Name())) {
 			return filepath.SkipDir
 		}
 

--- a/internal/collect.go
+++ b/internal/collect.go
@@ -20,13 +20,15 @@ type testf struct {
 	Name string
 }
 
-func ignoreDir(name string) bool {
-	switch name {
-	case "testdata", "vendor":
-		return true
-	default:
+func isGoModule(path string) bool {
+	_, err := os.Lstat(filepath.Join(path, "go.mod"))
+	if os.IsNotExist(err) {
 		return false
 	}
+	if err != nil {
+		panic(err)
+	}
+	return true
 }
 
 func Collect(root string) ([]testf, error) {
@@ -37,7 +39,7 @@ func Collect(root string) ([]testf, error) {
 		}
 
 		// Don't collect testdata directories.
-		if info.IsDir() && ignoreDir(filepath.Base(info.Name())) {
+		if info.IsDir() && (filepath.Base(info.Name()) == "testdata" || (info.Name() != root && isGoModule(info.Name()))) {
 			return filepath.SkipDir
 		}
 

--- a/internal/collect.go
+++ b/internal/collect.go
@@ -39,7 +39,9 @@ func Collect(root string) ([]testf, error) {
 		}
 
 		// Don't collect testdata directories.
-		if info.IsDir() && (filepath.Base(info.Name()) == "testdata" || (info.Name() != root && isGoModule(info.Name()))) {
+		if info.IsDir() &&
+			(filepath.Base(info.Name()) == "testdata" || filepath.Base(info.Name()) == "vendor" ||
+				(info.Name() != root && isGoModule(info.Name()))) {
 			return filepath.SkipDir
 		}
 

--- a/main.go
+++ b/main.go
@@ -73,8 +73,8 @@ func (p prog) run() (string, error) {
 
 	switch p.output {
 	case "env":
-		return fmt.Sprintf("SHARD_TESTS=%s\nSHARD_PATHS=%s", pattern, strings.Join(paths, " ")), nil
+		return fmt.Sprintf(`SHARD_TESTS="%s"\nSHARD_PATHS="%s"`, pattern, strings.Join(paths, " ")), nil
 	default:
-		return fmt.Sprintf("-run %s  %s", pattern, strings.Join(paths, " ")), nil
+		return fmt.Sprintf(`-run "%s"  %s`, pattern, strings.Join(paths, " ")), nil
 	}
 }


### PR DESCRIPTION
This PR makes 3 changes file discovery:

- It ignores directories called `vendor`, since that name is commonly used by go libraries to house other libraries.
- It changes the default output to quote the search string `-run "^(TestOne|TestTwo)$" ./somePackage` instead of `-run ^(TestOne|TestTwo)$ ./somePackage`.
- It excludes nested modules from test discovery.

While these changes are generically positive, they are motivated by https://github.com/pulumi/pulumi-terraform-bridge/pull/2832.