### PR TITLE
Add name clash check

### DIFF
--- a/internal/collect.go
+++ b/internal/collect.go
@@ -81,35 +81,17 @@ func Collect(root string) ([]testf, error) {
 }
 
 func CheckForClashingTestNames(tests []testf) []string {
-	slices.SortStableFunc(tests, func(a, b testf) int {
+	slices.SortFunc(tests, func(a, b testf) int {
 		return strings.Compare(a.Name, b.Name)
 	})
 
-	repeats := map[string]struct{}{}
-	prefixed := map[string]int{}
-
+	warnings := []string{}
 	for i := 0; i < len(tests)-1; i++ {
-		for j := i + 1; j < len(tests); j++ {
-			if tests[i].Name == tests[j].Name {
-				repeats[tests[i].Name] = struct{}{}
-				continue
-			}
-			if strings.HasPrefix(tests[i].Name, tests[j].Name) {
-				prefixed[tests[j].Name]++
-			}
-			if strings.HasPrefix(tests[j].Name, tests[i].Name) {
-				prefixed[tests[i].Name]++
-			}
+		if tests[i].Name == tests[i+1].Name {
+			warnings = append(warnings, fmt.Sprintf("test name %q exists in multiple packages, consider renaming it", tests[i].Name))
 		}
 	}
 
-	warnings := []string{}
-	for name := range repeats {
-		warnings = append(warnings, fmt.Sprintf("test name %q exists in multiple packages, consider renaming it", name))
-	}
-	for name := range prefixed {
-		warnings = append(warnings, fmt.Sprintf("test name %q is prefixed by %d other tests, consider renaming it", name, prefixed[name]))
-	}
 	return warnings
 }
 
@@ -134,6 +116,7 @@ func Assign(tests []testf, index int, total int, seed int64) (names, paths []str
 
 	// De-dupe.
 	slices.Sort(names)
+	names = slices.Compact(names)
 	slices.Sort(paths)
 	paths = slices.Compact(paths)
 

--- a/internal/collect.go
+++ b/internal/collect.go
@@ -80,6 +80,39 @@ func Collect(root string) ([]testf, error) {
 	return tests, err
 }
 
+func CheckForClashingTestNames(tests []testf) []string {
+	slices.SortStableFunc(tests, func(a, b testf) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+
+	repeats := map[string]struct{}{}
+	prefixed := map[string]int{}
+
+	for i := 0; i < len(tests)-1; i++ {
+		for j := i + 1; j < len(tests); j++ {
+			if tests[i].Name == tests[j].Name {
+				repeats[tests[i].Name] = struct{}{}
+				continue
+			}
+			if strings.HasPrefix(tests[i].Name, tests[j].Name) {
+				prefixed[tests[j].Name]++
+			}
+			if strings.HasPrefix(tests[j].Name, tests[i].Name) {
+				prefixed[tests[i].Name]++
+			}
+		}
+	}
+
+	warnings := []string{}
+	for name := range repeats {
+		warnings = append(warnings, fmt.Sprintf("test name %q exists in multiple packages, consider renaming it", name))
+	}
+	for name := range prefixed {
+		warnings = append(warnings, fmt.Sprintf("test name %q is prefixed by %d other tests, consider renaming it", name, prefixed[name]))
+	}
+	return warnings
+}
+
 func Assign(tests []testf, index int, total int, seed int64) (names, paths []string) {
 	// Shuffle the tests.
 	if seed != 0 {
@@ -102,13 +135,6 @@ func Assign(tests []testf, index int, total int, seed int64) (names, paths []str
 	// De-dupe.
 	slices.Sort(names)
 	slices.Sort(paths)
-
-	names = slices.CompactFunc(names, func(l, r string) bool {
-		if l == r {
-			fmt.Fprintf(os.Stderr, "warning: %q exists in multiple packages, consider renaming it\n", l)
-		}
-		return l == r
-	})
 	paths = slices.Compact(paths)
 
 	return names, paths

--- a/internal/collect_test.go
+++ b/internal/collect_test.go
@@ -7,7 +7,6 @@ import (
 )
 
 func TestCollect(t *testing.T) {
-
 	t.Run("ignored", func(t *testing.T) {
 		tests, err := Collect("testdata/ignored")
 		if err != nil {
@@ -39,7 +38,6 @@ func TestCollect(t *testing.T) {
 			t.Fatalf("wanted\n\t%+v\nbut got\n\t%+v", want, tests)
 		}
 	})
-
 }
 
 func TestAssign(t *testing.T) {
@@ -136,6 +134,57 @@ func TestAssign(t *testing.T) {
 			}
 			if !reflect.DeepEqual(tt.wantNames, names) {
 				t.Errorf("wanted\n\t%+v\nbut got\n\t%+v", tt.wantNames, names)
+			}
+		})
+	}
+}
+
+func TestCheckForClashingTestNames(t *testing.T) {
+	tests := []struct {
+		name  string
+		tests []testf
+		want  []string
+	}{
+		{
+			name: "no clashes",
+			tests: []testf{
+				{Path: "package", Name: "Test1"},
+				{Path: "other/package", Name: "Test2"},
+			},
+			want: []string{},
+		},
+		{
+			name: "clashes with same name",
+			tests: []testf{
+				{Path: "package", Name: "Test1"},
+				{Path: "other/package", Name: "Test1"},
+			},
+			want: []string{"test name \"Test1\" exists in multiple packages, consider renaming it"},
+		},
+		{
+			name: "clashes with prefix first",
+			tests: []testf{
+				{Path: "package", Name: "Test"},
+				{Path: "other/package", Name: "TestSuffix"},
+			},
+			want: []string{"tests \"Test\" and \"TestSuffix\" have overlapping names, consider renaming one of them"},
+		},
+		{
+			name: "clashes with prefix second",
+			tests: []testf{
+				{Path: "package", Name: "TestSuffix"},
+				{Path: "other/package", Name: "Test"},
+			},
+			want: []string{"tests \"Test\" and \"TestSuffix\" have overlapping names, consider renaming one of them"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			warnings := CheckForClashingTestNames(tt.tests)
+
+			if !reflect.DeepEqual(tt.want, warnings) {
+				t.Errorf("wanted\n\t%+v\nbut got\n\t%+v", tt.want, warnings)
 			}
 		})
 	}

--- a/internal/collect_test.go
+++ b/internal/collect_test.go
@@ -162,20 +162,12 @@ func TestCheckForClashingTestNames(t *testing.T) {
 			want: []string{"test name \"Test1\" exists in multiple packages, consider renaming it"},
 		},
 		{
-			name: "clashes with prefix first",
+			name: "no clashes with prefix",
 			tests: []testf{
 				{Path: "package", Name: "Test"},
 				{Path: "other/package", Name: "TestSuffix"},
 			},
-			want: []string{"tests \"Test\" and \"TestSuffix\" have overlapping names, consider renaming one of them"},
-		},
-		{
-			name: "clashes with prefix second",
-			tests: []testf{
-				{Path: "package", Name: "TestSuffix"},
-				{Path: "other/package", Name: "Test"},
-			},
-			want: []string{"tests \"Test\" and \"TestSuffix\" have overlapping names, consider renaming one of them"},
+			want: []string{},
 		},
 	}
 

--- a/main.go
+++ b/main.go
@@ -21,10 +21,11 @@ func main() {
 	total := flag.Int("total", -1, "total number of shards")
 	seed := flag.Int64("seed", 0, "randomly shuffle tests using this seed")
 	output := flag.String("output", "", "output format (env)")
+	errorOnNameClash := flag.Bool("error-on-name-clash", false, "error on name clash")
 
 	flag.Parse()
 
-	p := prog{index: *index, total: *total, seed: *seed, root: *root, output: *output}
+	p := prog{index: *index, total: *total, seed: *seed, root: *root, output: *output, errorOnNameClash: *errorOnNameClash}
 	out, err := p.run()
 	if err != nil {
 		log.Fatal(err.Error())
@@ -33,11 +34,12 @@ func main() {
 }
 
 type prog struct {
-	index  int
-	total  int
-	seed   int64
-	root   string
-	output string
+	index            int
+	total            int
+	seed             int64
+	root             string
+	output           string
+	errorOnNameClash bool
 }
 
 func (p prog) run() (string, error) {
@@ -54,6 +56,14 @@ func (p prog) run() (string, error) {
 	tests, err := internal.Collect(p.root)
 	if err != nil {
 		log.Fatal(err)
+	}
+
+	warnings := internal.CheckForClashingTestNames(tests)
+	if len(warnings) > 0 {
+		if p.errorOnNameClash {
+			return "", fmt.Errorf("found %d issues:\n%s", len(warnings), strings.Join(warnings, "\n"))
+		}
+		fmt.Fprintf(os.Stderr, "warning: found %d issues:\n%s", len(warnings), strings.Join(warnings, "\n"))
 	}
 
 	names, paths := internal.Assign(tests, p.index, p.total, p.seed)

--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ func main() {
 	total := flag.Int("total", -1, "total number of shards")
 	seed := flag.Int64("seed", 0, "randomly shuffle tests using this seed")
 	output := flag.String("output", "", "output format (env)")
-	errorOnNameClash := flag.Bool("error-on-name-clash", false, "error on name clash")
+	errorOnNameClash := flag.Bool("error-on-name-clash", false, "error on test name clash")
 
 	flag.Parse()
 

--- a/main_test.go
+++ b/main_test.go
@@ -15,12 +15,12 @@ func TestProg(t *testing.T) {
 		{
 			name: "default output",
 			p:    prog{total: 1, root: "."},
-			want: `-run "^(?:TestAssign|TestCollect|TestProg)\$"  ./. ./internal`,
+			want: `-run "^(?:TestAssign|TestCheckForClashingTestNames|TestCollect|TestProg)\$"  ./. ./internal`,
 		},
 		{
 			name: "env output",
 			p:    prog{output: "env", total: 1, root: "."},
-			want: `SHARD_TESTS="^(?:TestAssign|TestCollect|TestProg)\$"
+			want: `SHARD_TESTS="^(?:TestAssign|TestCheckForClashingTestNames|TestCollect|TestProg)\$"
 SHARD_PATHS="./. ./internal"`,
 		},
 	}


### PR DESCRIPTION
This PR moves the existing check for clashing test names so that it is global instead of per-shard and adds a command line flag to error if a clash is encountered.

Name clashes reduce the effectiveness of sharding as the duplicated test names will all be run redundantly in all shards which hit them.